### PR TITLE
🐛 fix: native sdks update

### DIFF
--- a/RNAccessIOS.podspec
+++ b/RNAccessIOS.podspec
@@ -24,6 +24,6 @@ Pod::Spec.new do |s|
   #   requirement: { kind: 'upToNextMajorVersion', minimumVersion: '2.10.1' },
   #   products: ['AccessIOS']
   # )
-  s.dependency "AccessIOS", "2.10.1"
+  s.dependency "AccessIOS", "2.10.2"
   # s.vendored_frameworks = "ios/AccessIOS.xcframework"
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -81,7 +81,7 @@ dependencies {
   implementation "com.facebook.react:react-android"
 
   implementation "com.google.code.gson:gson:2.12.1"
-  implementation("tech.poool:access-android:1.7.1") {
+  implementation("tech.poool:access-android:1.7.2") {
     exclude group: "com.squareup.okhttp3", module: "logging-interceptor"
   }
 }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -45,5 +45,16 @@ target 'AccessExample' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # Fix for Xcode 26.4 build error
+    installer.pods_project.targets.each do |target|
+      if target.name == 'fmt'
+        target.build_configurations.each do |config|
+          config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
+        end
+      end
+    end
+
+
   end
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AccessIOS (2.10.1)
+  - AccessIOS (2.10.2)
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - fast_float (8.0.0)
@@ -1893,6 +1893,35 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
+  - react-native-pager-view (8.0.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - SwiftUIIntrospect (~> 1.0)
+    - Yoga
   - React-NativeModulesApple (0.83.2):
     - boost
     - DoubleConversion
@@ -2450,8 +2479,8 @@ PODS:
     - React-perflogger (= 0.83.2)
     - React-utils (= 0.83.2)
     - SocketRocket
-  - RNAccessIOS (1.0.6):
-    - AccessIOS (= 2.10.1)
+  - RNAccessIOS (1.1.4):
+    - AccessIOS (= 2.10.2)
     - boost
     - DoubleConversion
     - fast_float
@@ -2508,6 +2537,7 @@ PODS:
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
+  - SwiftUIIntrospect (1.3.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2555,6 +2585,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
+  - react-native-pager-view (from `../node_modules/react-native-pager-view`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-networking (from `../node_modules/react-native/ReactCommon/react/networking`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
@@ -2597,6 +2628,7 @@ SPEC REPOS:
   trunk:
     - AccessIOS
     - SocketRocket
+    - SwiftUIIntrospect
 
 EXTERNAL SOURCES:
   boost:
@@ -2686,6 +2718,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
+  react-native-pager-view:
+    :path: "../node_modules/react-native-pager-view"
   React-NativeModulesApple:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios"
   React-networking:
@@ -2760,14 +2794,14 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  AccessIOS: 5e1883f5e15770562fbafcb8c2ba715daff3478c
+  AccessIOS: 5274a0af5b48e9320b0e97d1484afdc73bd4db69
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: f1200e6ef6cf24885501668bdbb9eff4cf48843f
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 70352f3627765f8e7c48fff40aee0533e38ad819
+  hermes-engine: 5260bf940544bfdaaf750e23d4b49d94068ae052
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 3b915a7b166f7d04eaeb4ae30aaf24236a016551
   RCTRequired: fcfec6ba532cfe4e53c49e0a4061b5eff87f8c64
@@ -2804,6 +2838,7 @@ SPEC CHECKSUMS:
   React-logger: 49a2029a7c055bf0ef005fec0955c2548fe88f12
   React-Mapbuffer: 2859d1e7202df918c8578db97deb5767b337dff9
   React-microtasksnativemodule: e811b68410bc71e77b91a700b527dc39661f6fc4
+  react-native-pager-view: d7d2aa47f54343bf55fdcee3973503dd27c2bd37
   React-NativeModulesApple: 5327be5c0d9734f0c6db2219f3c20c13aef13884
   React-networking: 659753d9f58d683f3aee733c542bdae2b23f85d1
   React-oscompat: 173f032a95ee30e92bbd28cd9b4626de0977f828
@@ -2837,11 +2872,12 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: d69159b417e8c9d82b8fe4d0a27def4c3e8f767f
   ReactCodegen: 7456de84eece108533dd15d52a6fc123802cf2ce
   ReactCommon: b3a9c15f0c2f4849cac0cf01e626cfa7f1a2e887
-  RNAccessIOS: a89480dc6049f816cb35a9ee740b67bcb59b592d
+  RNAccessIOS: fe4747232cd50a1d8c0bd8a182ce40e978b34c77
   RNPermissions: 5948049420432e86de5657c90ade83d50ed590dc
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
+  SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d
   Yoga: 3d56e80930898685da43cbf53b5843932df8e765
 
-PODFILE CHECKSUM: 5c655b08514f25a23639b56226d44be38c80849c
+PODFILE CHECKSUM: 6f7247d4dbbe8f252ef3a5f100c77be07060404f
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1893,35 +1893,6 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-pager-view (8.0.0):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - SwiftUIIntrospect (~> 1.0)
-    - Yoga
   - React-NativeModulesApple (0.83.2):
     - boost
     - DoubleConversion
@@ -2537,7 +2508,6 @@ PODS:
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
-  - SwiftUIIntrospect (1.3.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2585,7 +2555,6 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
-  - react-native-pager-view (from `../node_modules/react-native-pager-view`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-networking (from `../node_modules/react-native/ReactCommon/react/networking`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
@@ -2628,7 +2597,6 @@ SPEC REPOS:
   trunk:
     - AccessIOS
     - SocketRocket
-    - SwiftUIIntrospect
 
 EXTERNAL SOURCES:
   boost:
@@ -2718,8 +2686,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
-  react-native-pager-view:
-    :path: "../node_modules/react-native-pager-view"
   React-NativeModulesApple:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios"
   React-networking:
@@ -2838,7 +2804,6 @@ SPEC CHECKSUMS:
   React-logger: 49a2029a7c055bf0ef005fec0955c2548fe88f12
   React-Mapbuffer: 2859d1e7202df918c8578db97deb5767b337dff9
   React-microtasksnativemodule: e811b68410bc71e77b91a700b527dc39661f6fc4
-  react-native-pager-view: d7d2aa47f54343bf55fdcee3973503dd27c2bd37
   React-NativeModulesApple: 5327be5c0d9734f0c6db2219f3c20c13aef13884
   React-networking: 659753d9f58d683f3aee733c542bdae2b23f85d1
   React-oscompat: 173f032a95ee30e92bbd28cd9b4626de0977f828
@@ -2875,7 +2840,6 @@ SPEC CHECKSUMS:
   RNAccessIOS: fe4747232cd50a1d8c0bd8a182ce40e978b34c77
   RNPermissions: 5948049420432e86de5657c90ade83d50ed590dc
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d
   Yoga: 3d56e80930898685da43cbf53b5843932df8e765
 
 PODFILE CHECKSUM: 6f7247d4dbbe8f252ef3a5f100c77be07060404f


### PR DESCRIPTION
Upgrades AccessIOS to `2.10.2`.
Upgrades Access-android to `1.7.2`.

Also fixes XCode 26.4 C++ version error.