### PR TITLE
🐛 fix(ios): paywall controller parent crash

### DIFF
--- a/ios/PaywallView.h
+++ b/ios/PaywallView.h
@@ -7,6 +7,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface PaywallView : RCTViewComponentView
+
+- (void)remove;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/PaywallView.h
+++ b/ios/PaywallView.h
@@ -7,9 +7,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface PaywallView : RCTViewComponentView
-
-- (void)remove;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/PaywallView.mm
+++ b/ios/PaywallView.mm
@@ -48,39 +48,21 @@ using namespace facebook::react;
     [self reinit];
 }
 
+- (void)paywallWillDisappear
+{
+    
+}
+
 + (ComponentDescriptorProvider)componentDescriptorProvider
 {
     return concreteComponentDescriptorProvider<PaywallViewComponentDescriptor>();
 }
 
-- (void)didMoveToWindow
+- (void)resolveViewControllerState
 {
-    [super didMoveToWindow];
-    
-    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(resolveViewControllerState) object:nil];
-    [self performSelector:@selector(resolveViewControllerState) withObject:nil afterDelay:0.0];
-}
-
--(void)resolveViewControllerState
-{
-    UIViewController *parentVC = self.window ? [self findParentViewController] : nil;
-
-    // Making sure controller detaches from its parent, to avoid dumb recycle crash from react native.
-    if (controller.parentViewController != parentVC) {
-        if (controller.parentViewController) {
-            [controller willMoveToParentViewController:nil];
-            [controller removeFromParentViewController];
-        }
-
-        if (parentVC) {
-            [parentVC addChildViewController:controller];
-            [controller didMoveToParentViewController:parentVC];
-        }
-    }
-    
     // Manually triggering controller.viewWillAppear(_:). Cuz' it's not being fired. Cuz react native dumb af.
     if (self.window) {
-        if (!isAppeared) {            
+        if (!isAppeared) {
             [controller beginAppearanceTransition:YES animated:NO];
             [controller endAppearanceTransition];
             isAppeared = YES;
@@ -94,21 +76,10 @@ using namespace facebook::react;
     }
 }
 
-- (UIViewController *)findParentViewController
-{
-    UIResponder *responder = self;
-    while (responder) {
-        if ([responder isKindOfClass:[UIViewController class]]) {
-            return (UIViewController *)responder;
-        }
-        responder = [responder nextResponder];
-    }
-    return nil;
-}
-
 - (instancetype)initWithFrame:(CGRect)frame
 {
     if (self = [super initWithFrame:frame]) {
+                
         static const auto defaultProps = std::make_shared<const PaywallViewProps>();
         _props = defaultProps;
 
@@ -130,8 +101,6 @@ using namespace facebook::react;
 
 - (void)cleanUp
 {
-    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(resolveViewControllerState) object:nil];
-    
     [access destroy];
     access = nil;
     cleaned = YES;
@@ -139,11 +108,6 @@ using namespace facebook::react;
     CGRect frame = self.contentView.frame;
     frame.size.height = 0.0;
     self.contentView.frame = frame;
-    
-    if (controller.parentViewController) {
-        [controller willMoveToParentViewController:nil];
-        [controller removeFromParentViewController];
-    }
 
     controller.view.frame = frame;
     [controller.view layoutSubviews];
@@ -183,7 +147,7 @@ using namespace facebook::react;
     [self createPaywall];
 }
 
-- (void) createPaywall
+- (void)createPaywall
 {
     BOOL isBottomSheet = [displayMode isEqualToString:@"bottom-sheet"];
 
@@ -500,7 +464,7 @@ using namespace facebook::react;
     }
 
     released = newViewProps.released;
-
+    
     if (newViewProps.released) {
         [super updateProps:props oldProps:oldProps];
         return;

--- a/ios/PaywallView.mm
+++ b/ios/PaywallView.mm
@@ -57,14 +57,25 @@ using namespace facebook::react;
 {
     [super didMoveToWindow];
 
-    if (parented) { return; }
+    UIViewController *parentVC = self.window ? [self findParentViewController] : nil;
 
-    UIViewController *parentVC = [self findParentViewController];
+    // Making sure controller detaches from its parent, to avoid dumb recycle crash from react native.
+    if (controller.parentViewController != parentVC) {
+        if (controller.parentViewController) {
+            [controller willMoveToParentViewController:nil];
+            [controller removeFromParentViewController];
+        }
 
-    if (parentVC != nil) {
-        [parentVC addChildViewController: controller];
-        [controller didMoveToParentViewController: parentVC];
-        parented = YES;
+        if (parentVC) {
+            [parentVC addChildViewController:controller];
+            [controller didMoveToParentViewController:parentVC];
+        }
+    }
+    
+    // Manually triggering controller.viewWillAppear(_:). Cuz' it's not being fired. Cuz react native dumb af.
+    if (self.window) {
+        [controller beginAppearanceTransition:YES animated:NO];
+        [controller endAppearanceTransition];
     }
 }
 
@@ -112,6 +123,12 @@ using namespace facebook::react;
     CGRect frame = self.contentView.frame;
     frame.size.height = 0.0;
     self.contentView.frame = frame;
+    
+    if (parented) {
+        [controller willMoveToParentViewController:nil];
+        [controller removeFromParentViewController];
+        parented = NO;
+    }
 
     controller.view.frame = frame;
     [controller.view layoutSubviews];

--- a/ios/PaywallView.mm
+++ b/ios/PaywallView.mm
@@ -34,9 +34,9 @@ using namespace facebook::react;
     
     Access * access;
 
-    BOOL parented;
     BOOL cleaned;
     BOOL released;
+    BOOL isAppeared;
 }
 
 - (void)paywallWillAppear
@@ -56,7 +56,13 @@ using namespace facebook::react;
 - (void)didMoveToWindow
 {
     [super didMoveToWindow];
+    
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(resolveViewControllerState) object:nil];
+    [self performSelector:@selector(resolveViewControllerState) withObject:nil afterDelay:0.0];
+}
 
+-(void)resolveViewControllerState
+{
     UIViewController *parentVC = self.window ? [self findParentViewController] : nil;
 
     // Making sure controller detaches from its parent, to avoid dumb recycle crash from react native.
@@ -74,8 +80,17 @@ using namespace facebook::react;
     
     // Manually triggering controller.viewWillAppear(_:). Cuz' it's not being fired. Cuz react native dumb af.
     if (self.window) {
-        [controller beginAppearanceTransition:YES animated:NO];
-        [controller endAppearanceTransition];
+        if (!isAppeared) {            
+            [controller beginAppearanceTransition:YES animated:NO];
+            [controller endAppearanceTransition];
+            isAppeared = YES;
+        }
+    } else { // and viewWillDisappear here
+        if (isAppeared) {
+            [controller beginAppearanceTransition:NO animated:NO];
+            [controller endAppearanceTransition];
+            isAppeared = NO;
+        }
     }
 }
 
@@ -102,7 +117,7 @@ using namespace facebook::react;
 
         cleaned = NO;
         released = NO;
-        parented = NO;
+        isAppeared = NO;
 
         self.contentView = controller.view;
 
@@ -115,19 +130,19 @@ using namespace facebook::react;
 
 - (void)cleanUp
 {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(resolveViewControllerState) object:nil];
+    
     [access destroy];
     access = nil;
     cleaned = YES;
-    parented = NO;
 
     CGRect frame = self.contentView.frame;
     frame.size.height = 0.0;
     self.contentView.frame = frame;
     
-    if (parented) {
+    if (controller.parentViewController) {
         [controller willMoveToParentViewController:nil];
         [controller removeFromParentViewController];
-        parented = NO;
     }
 
     controller.view.frame = frame;

--- a/ios/PaywallViewController.h
+++ b/ios/PaywallViewController.h
@@ -5,6 +5,7 @@
 @protocol PaywallViewControllerDelegate <NSObject>
 
 - (void)paywallWillAppear;
+- (void)paywallWillDisappear;
 
 @end
 

--- a/ios/PaywallViewController.mm
+++ b/ios/PaywallViewController.mm
@@ -14,6 +14,9 @@
 }
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
+    if ([self.delegate respondsToSelector:@selector(paywallWillDisappear)]) {
+        [self.delegate paywallWillDisappear];
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated {


### PR DESCRIPTION
Fixes a crash ocurring when using react-native-pager-view old version (about 6.8.something). 
The PaywallController of the React-Native bridge is now supposed to now when to demount itself.

Personal note: this thing is hacky as hell.